### PR TITLE
Fix OSX TeXLive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
       r: release
       env: LINTR_COMMENT_BOT=true
 
+# macOS 10.12 version
+osx_image: xcode9.2
+
 # BayesLogit needs the gfortran compiler
 apt_packages:
   - gfortran
@@ -39,11 +42,6 @@ apt_packages:
 # Install BayesLogit 0.6 using devtools
 before_install:
   - Rscript -e 'install.packages("devtools"); require(devtools); install_version("BayesLogit", version = "0.6")'
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      sudo tlmgr option repository http://mirror.ctan.org/systems/texlive/tlnet;
-      sudo tlmgr update --self
-      sudo tlmgr install inconsolata upquote courier courier-scaled helvetic;
-   fi
 
 # Install PolyaGamma using devtools::install_github
 r_github_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ apt_packages:
 # Install BayesLogit 0.6 using devtools
 before_install:
   - Rscript -e 'install.packages("devtools"); require(devtools); install_version("BayesLogit", version = "0.6")'
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      sudo tlmgr option repository http://mirror.ctan.org/systems/texlive/tlnet;
+      sudo tlmgr update --self
+      sudo tlmgr install inconsolata upquote courier courier-scaled helvetic;
+   fi
 
 # Install PolyaGamma using devtools::install_github
 r_github_packages:

--- a/R/pcb_vb_classn_sb.R
+++ b/R/pcb_vb_classn_sb.R
@@ -103,7 +103,7 @@ load_dataset <- function(dataset_input_list = list(name = "toy", n = 200)) {
 #'   which is an effective sample size.
 #' @param min_stick_breaks The minimal number of stick-breaks.
 #' @param threshold The threshold of stick remaining below which the function
-#'   stops looking for more stick-breaks. It correspondes to epsilon in the
+#'   stops looking for more stick-breaks. It corresponds to epsilon in the
 #'   paper, at the bottom of page 5 and in algorithm 2 in page 12.
 #' @return A vector of stick-breaks summing to one.
 #' @examples
@@ -204,7 +204,7 @@ anpl <- function(dataset,
   }
   # Generate prior samples
 
-  # `x_prior` is a `n_bootstrap x n_centering_model_samples` matrix:
+  # `x_prior` is a `concentration x n_centering_model_samples` matrix:
   # each row represents a set of prior samples for a particular gamma element.
 
   # This for loop can be be parallelised
@@ -362,7 +362,7 @@ append_to_plot <- function(plot_df, sample, method,
 
 #' Wrapper function for the script part of the code.
 #'
-#' Note: this function takes about an hour to run on a mac laptop.
+#' Note: this function takes several hours to run on a mac laptop.
 #'
 #' @param use_bayes_logit Whether to use this package or the alternative
 #'   from Kaspar Martens


### PR DESCRIPTION
Travis updated its macOS distribution and the version in `master` now fails, as you can see from commit 0a1c4b9, which only changed comments.

The reason is that TeXLive is now 2019, when the repository it pulls from supports only 2016-2018. So the system cannot install the `inconsolata` font:

```
sudo tlmgr install inconsolata upquote courier courier-scaled helvetic
tlmgr: The TeX Live versions supported by the repository
http://mirrors.concertpass.com/tex-archive/systems/texlive/tlnet
  (2016--2018)
do not include the version of the local installation
  (2019).
```

The `inconsolata` font is required to build vignettes:

```
* checking PDF version of manual ... WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
LaTeX errors found:
! LaTeX Error: File `inconsolata.sty' not found.
Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)
! Emergency stop.
<read *> 
         
l.276 ^^M
         
!  ==> Fatal error occurred, no output PDF file produced!
* checking PDF version of manual without hyperrefs or index ... ERROR
* DONE
Status: 1 ERROR, 1 WARNING
See
  ‘/Users/travis/build/alan-turing-institute/PosteriorBootstrap/PosteriorBootstrap.Rcheck/00check.log’
for details.
```

Since warnings are errors, the build fails. I tried to change the TeX repo with `sudo tlmgr option repository http://mirror.ctan.org/systems/texlive/tlnet;` in commit d5843a7, but this repo is also out of data. @jemrobinson suggested downgrading the version of OSX, which fixed it in 75f1a07.