### PR TITLE
Use the standard MIT licence

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^LICENSE\.md$
 ^codecov\.yml$
 ^\.lintr$
 ^\.travis\.yml$

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,2 @@
-# MIT License
-
-Copyright (c) 2019 The Alan Turing Institute
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2019
+COPYRIGHT HOLDER: The Alan Turing Institute

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2019 Miguel Morin
+Copyright (c) 2019 The Alan Turing Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2019 Miguel Morin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #8. Discussion below duplicated from the issue.

# GPL dependencies in general

In general, we [technically cannot use packages that depend on GPL 2 and 3](https://opensource.stackexchange.com/questions/4414/if-my-r-package-uses-gpl-packages-does-mine-automatically-inherit-gpl):

> if one is GPL 2-only, it technically would not be compatible (per the FSF) with the GPL 3.
> ...
> these two versions are mutually incompatible so you cannot distribute a program that would depend on libraries under both licenses. To solve this hurdle, the best way is probably to write to the authors of the "GPL 2.0 only" packages and ask them to license their libraries under "GPL 2.0 or later" instead.

# GPL dependencies in R

But R [is different](https://github.com/tidyverse/ggplot2/issues/3272):

> I think the general interpretation of the GPL license in R (which is consistent with my reading of the GPL 2 right now) is that using the exported interface of a GPL-licensed package A in a package B does not mean B needs to have a GPL-compatible license. You're not redistributing or modifying A, you're just using it. The situation would be different if you copied substantial portions of ggplot2 code into your package, such that your package is a direct derivative of ggplot2.

> I note that rstan depends on ggplot2, so if my above understanding of the licenses were incorrect then rstan would be out of compliance and would have to fix their license.

> Relicensing a large open-source project such as ggplot2 is almost always impossible, because you'd have to get agreement from every contributor who ever worked on the code.

The authors of the `e1071` package said the same thing in an email thread:

> the CRAN maintainers think that *dependencies* on packages are not a
problem. This only occurs if you *combine* ("aggregate") code under GPL-2 and
GPL-3.

# We needn't switch to GPL in our current use of RStan

The only question left is whether our use of Rstan is a derived work of Rstan or Rcpp, in which case we'd need to switch to GPL. As we don't provide compiled files, [the RStan authors don't think so](https://github.com/stan-dev/rstan/issues/628#issuecomment-488323724):

> If you just provide the .stan files in your package, then it isn't necessarily
> a derived work of anything. But it has to be compiled at run-time, which is
> bad. If you provide the C++ files to pre-compile the Stan models on CRAN, they
> have the `#include <Rcpp.h>` lines that copies in all of the GPL'd headers
> from Rcpp, making it a derived work of Rcpp.

[The step-by-step tutorial](https://cran.r-project.org/web/packages/rstantools/vignettes/minimal-rstan-package.html) shows that to compile a model, we have to follow the RStan package skeleton, which creates the right structure:

```
library("rstantools")
rstan_package_skeleton(path = 'rstanlm')
```

and the code that compiles the model into C++ is in `tools/make_cc.R`:

```
make_cc <- function(file) {
  file <- sub("\\.cc$", ".stan", file)
  cppcode <- rstan::stanc(file, allow_undefined = TRUE,
                          obfuscate_model_name = FALSE)$cppcode
	...
}
```

We decided to not compile the Stan model and to stay with the MIT license because it is the preferred license of the institute, because using the RStan package would represent a significant amount of work, and because we want to allow users to provide their own Stan models.

# MIT license

The R packages book [suggests](https://r-pkgs.org/whole-game.html#use_mit_license) this standard MIT license:

```r
usethis::use_mit_license("The Alan Turing Institute")
```

where `DESCRIPTION` has simply `License: MIT + file LICENSE`, `LICENSE` has only the year and the copyright holder, and `LICENSE.md` has the full MIT license, which is added to `.Rbuildignore` to be in the source code but not in the tarball. Otherwise, CRAN may complain that our text in `LICENSE` is not standard.