### PR TITLE
Fix OSX build problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,10 @@ before_install:
   - |
     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
-      cat << 'EOF' > ~/.R/Makevars
-        # The following statements are required to use homebrew clang with openmp support
-        CC=/usr/local/clang4/bin/clang
-        CXX=/usr/local/clang4/bin/clang++
-        LDFLAGS=-L/usr/local/clang4/lib
-        # End clang4 inclusion statements
-      EOF
+      # The following statements are required to use homebrew clang with openmp support
+      echo "CC=/usr/local/clang4/bin/clang" > ~/.R/Makevars
+      echo "CXX=/usr/local/clang4/bin/clang++" >> ~/.R/Makevars
+      echo "LDFLAGS=-L/usr/local/clang4/lib" >> ~/.R/Makevars
     fi
 
 # Explicitly enable the lintr-bot for one build (this avoids duplicate comments).

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
         CXX=/usr/local/clang4/bin/clang++
         LDFLAGS=-L/usr/local/clang4/lib
         # End clang4 inclusion statements
-  	  EOF
+      EOF
     fi
 
 # Explicitly enable the lintr-bot for one build (this avoids duplicate comments).

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,20 @@ r:
 addons:
   homebrew:
     packages:
+    - libomp
     - llvm
+
+before_install:
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      mkdir -p ~/.R
+      cat <<- EOF > ~/.R/Makevars
+        # The following statements are required to use homebrew clang with openmp support
+        CC=/usr/local/clang4/bin/clang
+        CXX=/usr/local/clang4/bin/clang++
+        LDFLAGS=-L/usr/local/clang4/lib
+        # End clang4 inclusion statements
+  	  EOF
+    fi
 
 # Explicitly enable the lintr-bot for one build (this avoids duplicate comments).
 # Travis treats builds with different environment variables as different builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ addons:
 
 before_install:
   - |
+    ls /usr/local/
+    ls /usr/local/clang*
     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
       # The following statements are required to use homebrew clang with openmp support

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,24 +22,13 @@ r:
 addons:
   homebrew:
     packages:
-    #  - cmake
-    #  - gcc
-    # - libomp
     - llvm
 
 before_install:
   - |
-    brew link --overwrite gcc
-    ls /usr/local/
-    ls /usr/local/clang*
-    echo "$(brew --prefix llvm)/bin"
-    ls "$(brew --prefix llvm)/bin"
     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
-      # The following statements are required to use homebrew clang with openmp support
-      # echo "CC=/usr/local/clang4/bin/clang" > ~/.R/Makevars
-      # echo "CXX=/usr/local/clang4/bin/clang++" >> ~/.R/Makevars
-      # echo "LDFLAGS=-L/usr/local/clang4/lib" >> ~/.R/Makevars
+      # Ensure that R will use clang from homebrew llvm (which includes openmp support)
       echo "CC=$(brew --prefix llvm)/bin/clang" > ~/.R/Makevars
       echo "CXX=$(brew --prefix llvm)/bin/clang++" >> ~/.R/Makevars
       echo "LDFLAGS=-L$(brew --prefix llvm)/lib" >> ~/.R/Makevars
@@ -62,13 +51,8 @@ matrix:
       r: release
       env: LINTR_COMMENT_BOT=true
 
-# The lintr R package is slightly behind its Github version but it is fine for
-# now. If we have lintr problems in the future, revert to
-# ```
-# r_github_packages:
-#   - jimhester/lintr
-# ```
-
+# Add R packages from CRAN. If newer versions are needed, r_github_packages
+# can be used instead
 r_packages:
   - covr
   - lintr

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ addons:
     - llvm
 
 before_install:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+  - |
+    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
       cat <<- EOF > ~/.R/Makevars
         # The following statements are required to use homebrew clang with openmp support

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - |
     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
-      cat <<- EOF > ~/.R/Makevars
+      cat << 'EOF' > ~/.R/Makevars
         # The following statements are required to use homebrew clang with openmp support
         CC=/usr/local/clang4/bin/clang
         CXX=/usr/local/clang4/bin/clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,27 @@ r:
 addons:
   homebrew:
     packages:
-    - libomp
+    #  - cmake
+    #  - gcc
+    # - libomp
     - llvm
 
 before_install:
   - |
+    brew link --overwrite gcc
     ls /usr/local/
     ls /usr/local/clang*
+    echo "$(brew --prefix llvm)/bin"
+    ls "$(brew --prefix llvm)/bin"
     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
       mkdir -p ~/.R
       # The following statements are required to use homebrew clang with openmp support
-      echo "CC=/usr/local/clang4/bin/clang" > ~/.R/Makevars
-      echo "CXX=/usr/local/clang4/bin/clang++" >> ~/.R/Makevars
-      echo "LDFLAGS=-L/usr/local/clang4/lib" >> ~/.R/Makevars
+      # echo "CC=/usr/local/clang4/bin/clang" > ~/.R/Makevars
+      # echo "CXX=/usr/local/clang4/bin/clang++" >> ~/.R/Makevars
+      # echo "LDFLAGS=-L/usr/local/clang4/lib" >> ~/.R/Makevars
+      echo "CC=$(brew --prefix llvm)/bin/clang" > ~/.R/Makevars
+      echo "CXX=$(brew --prefix llvm)/bin/clang++" >> ~/.R/Makevars
+      echo "LDFLAGS=-L$(brew --prefix llvm)/lib" >> ~/.R/Makevars
     fi
 
 # Explicitly enable the lintr-bot for one build (this avoids duplicate comments).

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ r:
   - release
   - devel
 
+# Specify any additional packages that might be needed
+addons:
+  homebrew:
+    packages:
+    - llvm
+
 # Explicitly enable the lintr-bot for one build (this avoids duplicate comments).
 # Travis treats builds with different environment variables as different builds.
 # We therefore remove the one we don't want in order to replace it with the one

--- a/tests/testthat/test_anpl.R
+++ b/tests/testthat/test_anpl.R
@@ -146,18 +146,11 @@ test_that("Parallelisation works and is faster", {
   speedup <- durations[[1]] / durations[[2]]
   print(sprintf("Speedup: %3.2f (1 = same duration)", speedup))
 
-  # From tests on macOS on a local machine and Linux on a virtual machine, the
-  # speedups for n = 1000 vary between 1.75 and 1.89. So 1.6 seems a reasonable
-  # number on macOS. On Linux, the speedups vary between 1.5 and 1.56, so 1.4
-  # seems a reasonable number for now. In the future, revisit this "magic
-  # number" as needed.
-  if ("Darwin" == Sys.info()["sysname"]) {
-    expected_speedup <- 1.6
-  } else {
-    expected_speedup <- 1.4
-  }
-  expect_true(speedup > expected_speedup,
-              "Parallelization speedup is as expected")
+  # A priori, we do not know exactly what speed up will be available on a
+  # particular system. Testing with OSX gave values between 1.75 and 1.89 while
+  # on Linux the observed values were between 1.50 and 1.56. Given this
+  # uncertainty, we only want the tests to fail if *no speedup* is observed.
+  expect_true(speedup > 1.0, "Parallelization speedup is observed")
 })
 
 test_that("Adaptive non-parametric learning with posterior samples works", {


### PR DESCRIPTION
- Use compiler from Homebrew's LLVM installation to provide OpenMP support.
- Relax requirement on speed-up tests to simply be "parallel should be faster than serial"

Closes #72.